### PR TITLE
Add minimum version policy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ logging implementation. Libraries can use the logging API provided by this
 crate, and the consumer of those libraries can choose the logging
 implementation that is most suitable for its use case.
 
+
+## Minimum supported `rustc`
+
+`1.16.0+`
+
+This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
+
 ## Usage
 
 ## In libraries


### PR DESCRIPTION
Closes #252

Just calls out the explicit version of `rustc` that we test against in CI, along with a policy for how we'll change it. I copied it from `lazy-static`.

cc @sfackler are you on board with this? Or would you prefer something different?